### PR TITLE
Flag adding locking for oracle StorageRepo (for many writers case)

### DIFF
--- a/akka-tools-jdbc-journal/README.md
+++ b/akka-tools-jdbc-journal/README.md
@@ -161,3 +161,16 @@ for readability and is never read/used in this code.
 
 
 It would be a good idea to use this with the *JacksonJsonSerializer*-module, but it is not mandatory.
+
+In cluster mode, if you are streaming events across actors using eventsByTag(s) you should set the option ```useWriterLock=true``` on the repo, available from **akka-tools 1.1.3**.
+That requires this db-change:
+
+    create TABLE t_writerlock(
+        id INT,
+        PRIMARY KEY(id)
+    );
+    INSERT INTO t_writerlock VALUES (1);
+    
+Without ```useWriterLock=true``` events can be missed by the stream, since their journalIndex may become visible in the wrong order
+if there are overlapping transactions. ```useWriterLock=true``` ensures transactions execute serially even with many writers.
+    

--- a/akka-tools-jdbc-journal/src/main/resources/akka-tools-jdbc-journal-liquibase.sql
+++ b/akka-tools-jdbc-journal/src/main/resources/akka-tools-jdbc-journal-liquibase.sql
@@ -35,3 +35,9 @@ CREATE TABLE t_cluster_nodes (
     joined                                INT,
     PRIMARY KEY(nodeName)
 );
+
+--changeset jowa:Add-writer-lock-table dbms:all
+create TABLE t_writerlock(
+    id INT,
+    PRIMARY KEY(id)
+);

--- a/akka-tools-jdbc-journal/src/main/resources/akka-tools-jdbc-journal-liquibase.sql
+++ b/akka-tools-jdbc-journal/src/main/resources/akka-tools-jdbc-journal-liquibase.sql
@@ -41,3 +41,5 @@ create TABLE t_writerlock(
     id INT,
     PRIMARY KEY(id)
 );
+
+INSERT INTO t_writerlock VALUES (1);

--- a/akka-tools-jdbc-journal/src/main/scala/no/nextgentel/oss/akkatools/persistence/jdbcjournal/StorageRepo.scala
+++ b/akka-tools-jdbc-journal/src/main/scala/no/nextgentel/oss/akkatools/persistence/jdbcjournal/StorageRepo.scala
@@ -2,8 +2,8 @@ package no.nextgentel.oss.akkatools.persistence.jdbcjournal
 
 import java.time.{OffsetDateTime, ZoneId}
 import java.util.Date
-
 import javax.sql.DataSource
+
 import no.nextgentel.oss.akkatools.cluster.ClusterNodeRepo
 import org.slf4j.LoggerFactory
 import org.sql2o.data.{Row, Table}
@@ -59,8 +59,6 @@ case class StorageRepoConfig
 class StorageRepoImpl(sql2o: Sql2o, config:StorageRepoConfig, _errorHandler:Option[JdbcJournalErrorHandler]) extends StorageRepo with ClusterNodeRepo {
 
   def this(dataSource:DataSource, config:StorageRepoConfig = StorageRepoConfig(), _errorHandler:Option[JdbcJournalErrorHandler] = None) = this(new Sql2o(dataSource, new OracleQuirks()), config, _errorHandler)
-
-  val logger = LoggerFactory.getLogger("StorageLogger")
 
   import scala.collection.JavaConverters._
 

--- a/akka-tools-jdbc-journal/src/test/scala/no/nextgentel/oss/akkatools/persistence/jdbcjournal/StorageRepoTest.scala
+++ b/akka-tools-jdbc-journal/src/test/scala/no/nextgentel/oss/akkatools/persistence/jdbcjournal/StorageRepoTest.scala
@@ -49,7 +49,7 @@ class StorageRepoTest extends FunSuite with Matchers with BeforeAndAfterAll with
 
   private def runTestOnRepo(repo : StorageRepo) = {
     // Must remove bytearray to please the case class equals
-    def fix(dtos: List[JournalEntryDto]): List[JournalEntryDto] = {
+    def fix(dtos:List[JournalEntryDto]):List[JournalEntryDto] = {
       dtos.map {
         d =>
           d.copy(persistentRepr = null, timestamp = null)
@@ -65,30 +65,30 @@ class StorageRepoTest extends FunSuite with Matchers with BeforeAndAfterAll with
     val dto1 = JournalEntryDto(pid1.tag, pid1.uniqueId, 1L, dummyPersistentRepr, null, null)
 
     repo.insertPersistentReprList(Seq(dto1))
-    assert(List() == repo.loadJournalEntries(pid1, 0, 0, 10))
-    assert(fix(List(dto1)) == fix(repo.loadJournalEntries(pid1, 0, 1, 10)))
-    assert(fix(List(dto1)) == fix(repo.loadJournalEntries(pid1, 0, 2, 10)))
-    assert(List() == repo.loadJournalEntries(pid1, 0, 1, 0))
+    assert( List() == repo.loadJournalEntries(pid1, 0, 0, 10))
+    assert( fix(List(dto1)) == fix(repo.loadJournalEntries(pid1, 0, 1, 10)))
+    assert( fix(List(dto1)) == fix(repo.loadJournalEntries(pid1, 0, 2, 10)))
+    assert( List() == repo.loadJournalEntries(pid1, 0, 1, 0))
 
     assert(1 == repo.findHighestSequenceNr(pid1, 0))
 
     val dto2 = JournalEntryDto(pid1.tag, pid1.uniqueId, 2L, dummyPersistentRepr, null, null)
     repo.insertPersistentReprList(Seq(dto2))
 
-    assert(List() == repo.loadJournalEntries(pid1, 0, 0, 10))
-    assert(fix(List(dto1)) == fix(repo.loadJournalEntries(pid1, 0, 1, 10)))
-    assert(fix(List(dto1, dto2)) == fix(repo.loadJournalEntries(pid1, 0, 2, 10)))
-    assert(fix(List(dto2)) == fix(repo.loadJournalEntries(pid1, 2, 2, 10)))
-    assert(fix(List(dto1)) == fix(repo.loadJournalEntries(pid1, 0, 2, 1)))
+    assert( List() == repo.loadJournalEntries(pid1, 0, 0, 10))
+    assert( fix(List(dto1)) == fix(repo.loadJournalEntries(pid1, 0, 1, 10)))
+    assert( fix(List(dto1, dto2)) == fix(repo.loadJournalEntries(pid1, 0, 2, 10)))
+    assert( fix(List(dto2)) == fix(repo.loadJournalEntries(pid1, 2, 2, 10)))
+    assert( fix(List(dto1)) == fix(repo.loadJournalEntries(pid1, 0, 2, 1)))
 
     assert(2 == repo.findHighestSequenceNr(pid1, 0))
 
     repo.deleteJournalEntryTo(pid1, 1)
 
-    assert(fix(List(dto2)) == fix(repo.loadJournalEntries(pid1, 0, 2, 10)))
+    assert( fix(List(dto2)) == fix(repo.loadJournalEntries(pid1, 0, 2, 10)))
 
     repo.deleteJournalEntryTo(pid1, 2)
-    assert(List() == repo.loadJournalEntries(pid1, 0, 2, 10))
+    assert( List() == repo.loadJournalEntries(pid1, 0, 2, 10))
 
     assert(2 == repo.findHighestSequenceNr(pid1, 0))
   }

--- a/akka-tools-jdbc-journal/src/test/scala/no/nextgentel/oss/akkatools/persistence/jdbcjournal/StorageRepoTest.scala
+++ b/akka-tools-jdbc-journal/src/test/scala/no/nextgentel/oss/akkatools/persistence/jdbcjournal/StorageRepoTest.scala
@@ -58,7 +58,7 @@ class StorageRepoTest extends FunSuite with Matchers with BeforeAndAfterAll with
 
     val pid1 = PersistenceIdSingle("pId", getNextId())
 
-    assert(0 == repo.findHighestSequenceNr(pid1, 0))
+    assert( 0 == repo.findHighestSequenceNr(pid1, 0))
 
     val dummyPersistentRepr = Array[Byte]()
 
@@ -70,7 +70,7 @@ class StorageRepoTest extends FunSuite with Matchers with BeforeAndAfterAll with
     assert( fix(List(dto1)) == fix(repo.loadJournalEntries(pid1, 0, 2, 10)))
     assert( List() == repo.loadJournalEntries(pid1, 0, 1, 0))
 
-    assert(1 == repo.findHighestSequenceNr(pid1, 0))
+    assert( 1 == repo.findHighestSequenceNr(pid1, 0))
 
     val dto2 = JournalEntryDto(pid1.tag, pid1.uniqueId, 2L, dummyPersistentRepr, null, null)
     repo.insertPersistentReprList(Seq(dto2))
@@ -81,7 +81,7 @@ class StorageRepoTest extends FunSuite with Matchers with BeforeAndAfterAll with
     assert( fix(List(dto2)) == fix(repo.loadJournalEntries(pid1, 2, 2, 10)))
     assert( fix(List(dto1)) == fix(repo.loadJournalEntries(pid1, 0, 2, 1)))
 
-    assert(2 == repo.findHighestSequenceNr(pid1, 0))
+    assert( 2 == repo.findHighestSequenceNr(pid1, 0))
 
     repo.deleteJournalEntryTo(pid1, 1)
 
@@ -90,6 +90,6 @@ class StorageRepoTest extends FunSuite with Matchers with BeforeAndAfterAll with
     repo.deleteJournalEntryTo(pid1, 2)
     assert( List() == repo.loadJournalEntries(pid1, 0, 2, 10))
 
-    assert(2 == repo.findHighestSequenceNr(pid1, 0))
+    assert( 2 == repo.findHighestSequenceNr(pid1, 0))
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.18


### PR DESCRIPTION
- Uses SELECT FOR UPDATE to allow H2 testing (instead of a table lock, or DBMS_LOCK) which may be more appropriate for this (though TBH they are pretty equivalent).